### PR TITLE
Grammarly mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # XNNPACK
 
-XNNPACK is a highly optimized library of floating-point neural network inference operators for ARM, WebAssembly, and x86 (SSE2 level) platforms. XNNPACK is not intended for direct use by deep learning practitioners researchers; instead it provides low-level performance primitives for accelerating high-level machine learning frameworks, such as [MediaPipe](https://mediapipe.dev), [TensorFlow Lite](https://www.tensorflow.org/lite), and [TensorFlow.js](https://www.tensorflow.org/js).
+XNNPACK is a highly optimized library of floating-point neural network inference operators for ARM, WebAssembly, and x86 (SSE2 level) platforms. XNNPACK is not intended for direct use by deep learning practitioners researchers; instead, it provides low-level performance primitives for accelerating high-level machine learning frameworks, such as [MediaPipe](https://mediapipe.dev), [TensorFlow Lite](https://www.tensorflow.org/lite), and [TensorFlow.js](https://www.tensorflow.org/js).
 
 ## Supported Architectures
 
@@ -19,8 +19,8 @@ XNNPACK implements the following neural network operators:
 - 2D Average Pooling
 - 2D Max Pooling
 - 2D ArgMax Pooling (Max Pooling + indices)
-- 2D Unpooling
-- Add (tensors of same shape)
+- 2D Unspooling
+- Add (tensors of the same shape)
 - Global Average Pooling
 - Channel Shuffle
 - Fully Connected
@@ -28,11 +28,11 @@ XNNPACK implements the following neural network operators:
 - HardSwish
 - PReLU
 
-All operators in XNNPACK support NHWC layout, but additionally allow custom stride along the **C**hannel dimension. Thus, operators can consume a subset of channels in the input tensor, and produce a subset of channels in the output tensor, providing a zero-cost Channel Split and Channel Concatenation operations.
+All operators in XNNPACK support the NHWC layout but additionally allow custom stride along the **C**hannel dimension. Thus, operators can consume a subset of channels in the input tensor, and produce a subset of channels in the output tensor, providing a zero-cost Channel Split and Channel Concatenation operations.
 
 ## Performance
 
-The table below presents single-threaded performance of XNNPACK library on two generations of MobileNet models and three generations of Pixel phones.
+The table below presents the single-threaded performance of the XNNPACK library on two generations of MobileNet models and three generations of Pixel phones.
 
 | Model              | Pixel, ms | Pixel 2, ms | Pixel 3a, ms |
 | ------------------ | :-------: | :---------: | :----------: |
@@ -47,4 +47,4 @@ Benchmarked on October 9, 2019 with `end2end_bench --benchmark_min_time=5` on an
 
 ## Acknowledgements
 
-XNNPACK is a based on [QNNPACK](https://github.com/pytorch/QNNPACK) library. However, unlike QNNPACK, XNNPACK focuses entirely on floating-point operators, and its API is no longer compatible with QNNPACK.
+XNNPACK is based on [QNNPACK](https://github.com/pytorch/QNNPACK) library. However, unlike QNNPACK, XNNPACK focuses entirely on floating-point operators, and its API is no longer compatible with QNNPACK.


### PR DESCRIPTION
used coma
Unpooling - Unspooling
used the article